### PR TITLE
Update layer logic

### DIFF
--- a/macros/determine_data_layer.sql
+++ b/macros/determine_data_layer.sql
@@ -4,7 +4,7 @@
             when {{ table_name }} = '{{stage_name}}' then 'stage'
         {% endfor -%}
         {% for prod_name in var('leaner_query_prod_dataset_names') %}
-            when {{ table_name }} like '{{prod_name}}' then 'prod'
+            when {{ table_name }} = '{{prod_name}}' then 'prod'
         {% endfor %}
             when {{ table_name }} is null then 'None'
             else 'raw'

--- a/macros/determine_data_layer.sql
+++ b/macros/determine_data_layer.sql
@@ -1,10 +1,10 @@
 {% macro determine_data_layer(table_name) %}
         case
         {% for stage_name in var('leaner_query_stage_dataset_names') %}
-            when {{ table_name }} like '/%{{stage_name}}/%' then 'stage'
+            when {{ table_name }} = '{{stage_name}}' then 'stage'
         {% endfor -%}
         {% for prod_name in var('leaner_query_prod_dataset_names') %}
-            when {{ table_name }} like '/%{{prod_name}}/%' then 'prod'
+            when {{ table_name }} like '{{prod_name}}' then 'prod'
         {% endfor %}
             when {{ table_name }} is null then 'None'
             else 'raw'

--- a/models/marts/dim_job_table_view_references.sql
+++ b/models/marts/dim_job_table_view_references.sql
@@ -53,7 +53,7 @@ object_split as (
 
 add_layer as(
     select *,
-        concat(dim_job_table_view_references.project_id, '.', unique_tables.dataset_id, '.', unique_tables.table_or_view_id) as  qualified_table_name,
+        concat(project_id, '.', dataset_id, '.', table_or_view_id) as  qualified_table_name,
         {{ determine_data_layer('dataset_id') }} as layer_used
     from object_split
 )

--- a/models/marts/dim_job_table_view_references.sql
+++ b/models/marts/dim_job_table_view_references.sql
@@ -53,6 +53,7 @@ object_split as (
 
 add_layer as(
     select *,
+        concat(dim_job_table_view_references.project_id, '.', unique_tables.dataset_id, '.', unique_tables.table_or_view_id) as  qualified_table_name,
         {{ determine_data_layer('dataset_id') }} as layer_used
     from object_split
 )

--- a/models/marts/dim_job_table_view_references.sql
+++ b/models/marts/dim_job_table_view_references.sql
@@ -27,7 +27,7 @@ views as (
 tables as (
     select distinct
         job_id,
-        referenced_table as referenced_view_or_table
+        referenced_table as referenced_view_or_table,
         "table" as object_type
     from source
     cross join unnest(referenced_tables) as referenced_table
@@ -45,9 +45,9 @@ unioned as (
 
 object_split as (
     select *,
-        split(referenced_table, '/')[safe_offset(1)] as project_id,
-        split(referenced_table, '/')[safe_offset(3)] as dataset_id,
-        split(referenced_table, '/')[safe_offset(5)] as table_or_view_id
+        split(referenced_view_or_table, '/')[safe_offset(1)] as project_id,
+        split(referenced_view_or_table, '/')[safe_offset(3)] as dataset_id,
+        split(referenced_view_or_table, '/')[safe_offset(5)] as table_or_view_id
     from unioned
 ),
 

--- a/models/marts/dim_job_table_view_references.sql
+++ b/models/marts/dim_job_table_view_references.sql
@@ -19,7 +19,6 @@ views as (
     select distinct
         job_id,
         referenced_view as referenced_view_or_table,
-        {{ determine_data_layer('referenced_view') }} as layer_used,
         "view" as object_type
     from source
     cross join unnest(referenced_views) as referenced_view
@@ -28,8 +27,7 @@ views as (
 tables as (
     select distinct
         job_id,
-        referenced_table as referenced_view_or_table,
-        {{ determine_data_layer('referenced_table') }} as layer_used,
+        referenced_table as referenced_view_or_table
         "table" as object_type
     from source
     cross join unnest(referenced_tables) as referenced_table
@@ -43,6 +41,20 @@ unioned as (
 
     select *
     from tables
+),
+
+object_split as (
+    select *,
+        split(referenced_table, '/')[safe_offset(1)] as project_id,
+        split(referenced_table, '/')[safe_offset(3)] as dataset_id,
+        split(referenced_table, '/')[safe_offset(5)] as table_or_view_id
+    from unioned
+),
+
+add_layer as(
+    select *,
+        {{ determine_data_layer('dataset_id') }} as layer_used
+    from object_split
 )
 
 select distinct
@@ -50,4 +62,4 @@ select distinct
         'job_id'
     ]) }} as job_key,
     * except(job_id)
-from unioned
+from add_layer

--- a/models/reports/rpt_bigquery_table_usage_daily.sql
+++ b/models/reports/rpt_bigquery_table_usage_daily.sql
@@ -61,7 +61,8 @@ dim_job_table_view_references as(
 ),
 
 unique_tables as (
-    select distinct referenced_view_or_table as table_name
+    select 
+        distinct referenced_view_or_table as table_name
     from dim_job_table_view_references
 ),
 
@@ -79,10 +80,10 @@ aggregates as (
     select
         calendar.date_day as report_date, -- calendar
         unique_tables.table_name, -- dim_job_table
-        unique_tables.project_id,
-        unique_tables.dataset_id,
-        unique_tables.table_or_view_id,
-        concat(unique_tables.project_id, '.', unique_tables.dataset_id, '.', unique_tables.table_or_view_id) as qualified_table_name,
+        dim_job_table_view_references.project_id,
+        dim_job_table_view_references.dataset_id,
+        dim_job_table_view_references.table_or_view_id,
+        dim_job_table_view_references.qualified_table_name,
         dim_job_table_view_references.layer_used as layer, -- dim_job_table
         dim_user_agents.client_type, -- dim_user_agents
         coalesce(count(fct_executed_statements.job_key), 0) as total_queries_run,  -- cnt(job_key) from fct_executed_statements

--- a/models/reports/rpt_bigquery_table_usage_daily.sql
+++ b/models/reports/rpt_bigquery_table_usage_daily.sql
@@ -79,6 +79,10 @@ aggregates as (
     select
         calendar.date_day as report_date, -- calendar
         unique_tables.table_name, -- dim_job_table
+        unique_tables.project_id,
+        unique_tables.dataset_id,
+        unique_tables.table_or_view_id,
+        concat(unique_tables.project_id, '.', unique_tables.dataset_id, '.', unique_tables.table_or_view_id) as qualified_table_name,
         dim_job_table_view_references.layer_used as layer, -- dim_job_table
         dim_user_agents.client_type, -- dim_user_agents
         coalesce(count(fct_executed_statements.job_key), 0) as total_queries_run,  -- cnt(job_key) from fct_executed_statements

--- a/models/reports/rpt_bigquery_table_usage_daily.sql
+++ b/models/reports/rpt_bigquery_table_usage_daily.sql
@@ -105,7 +105,7 @@ aggregates as (
         on fct_executed_statements.user_key = dim_bq_users.user_key
     left outer join dim_job
         on fct_executed_statements.job_key = dim_job.job_key
-    group by 1, 2, 3, 4
+    group by 1, 2, 3, 4, 5, 6, 7, 8
 ),
 
 final as (

--- a/models/staging/bigquery_audit_log/stg_bigquery_audit_log__data_access.sql
+++ b/models/staging/bigquery_audit_log/stg_bigquery_audit_log__data_access.sql
@@ -86,9 +86,6 @@ renamed as (
             '$.jobChange.job.jobConfig.queryConfig.priority') as query_priority,
         JSON_EXTRACT_SCALAR(protopayload_auditlog.metadataJson,
             '$.jobChange.job.jobConfig.queryConfig.statementType') as statement_type,
-    --  split(destination_table, "/")[safe_offset(1)] as destination_project_id,
-    --     split(destination_table, "/")[safe_offset(3)] as destination_dataset_id,
-    --     split(destination_table, "/")[safe_offset(5)] as destination_table_id
     from source
     where JSON_EXTRACT(protopayload_auditlog.metadataJson, '$.jobChange') is not null
 )


### PR DESCRIPTION
Data layers logic was not working correctly b/c a "/" character was placed in front of a wildcard (versus in back).  Instead of just fixing that, I decided to fully implement the splitting of the resource names into project, dataset, and table/view ids so that we can do a direct comparison to find raw/stage/prod layers.  We also wanted this logic in place to have a more clean display of resource name anyway.

