### PR TITLE
Updating `dim_job` cluster_by field names

### DIFF
--- a/models/marts/dim_job.sql
+++ b/models/marts/dim_job.sql
@@ -1,7 +1,7 @@
 {{ 
     config(
         unique_key = ['job_key', 'caller_ip_address'],
-        cluster_by = ['job_key', 'dashboard_id', 'panel_id'],
+        cluster_by = ['job_key', 'grafana_dashboard_id', 'grafana_panel_id'],
         materialized = 'incremental'
 ) }}
 


### PR DESCRIPTION
In one of the last commits of the recent PR, we changed the names of two fields by adding `grafana_` to them. This was not reflected in the `cluster_by` config option.