### PR TITLE
Fix: add `project_id` to model

### DIFF
--- a/models/marts/dim_bigquery_users.sql
+++ b/models/marts/dim_bigquery_users.sql
@@ -21,7 +21,9 @@ with source as (
 ),
 
 user_emails as (
-    select distinct principal_email,
+    select distinct
+        principal_email,
+        project_id
     from source
 )
 


### PR DESCRIPTION
Left out `project_id` when I modified `dim_bigquery_users`. This PR adds that field in.