### PR TITLE
Updates for Fusion compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ logs/
 .DS_Store
 
 .user.yml
+dbt_internal_packages/

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -4,35 +4,28 @@ config-version: 2
 
 profile: 'leaner_query'
 
-require-dbt-version: [">=1.3.0", "<2.0.0"]
-
-target-path: "target"
+require-dbt-version: [">=1.10.5", "<3.0.0"]
 clean-targets:
-    - "target"
-    - "dbt_packages"
+  - "target"
+  - "dbt_packages"
 
 models:
-  leaner_query:    
+  leaner_query:
     +schema: leaner_query
     +tags:
       - leaner_query
 
     marts:
-      materialized: table
-
+      +materialized: table
     reports:
-      materialized: table
-
+      +materialized: table
     staging:
-      materialized: view
-
+      +materialized: view
     intermediate:
       +materialized: table
 
     utils:
-      materialized: ephemeral
-
-
+      +materialized: ephemeral
 vars:
   leaner_query_priority_threat_level_weight: .65
   leaner_query_priority_importance_level_weight: .35
@@ -40,7 +33,7 @@ vars:
   leaner_query_weight_threat__cost_to_query: 0.30
   leaner_query_weight_threat__cost_to_build: 0.25
   leaner_query_weight_threat__daily_errors: 0.10
-  leaner_query_weight_importance__service_account_queries: 0.2 
+  leaner_query_weight_importance__service_account_queries: 0.2
   leaner_query_weight_importance__dbt_queries: 0.2
   leaner_query_weight_importance__egress_use: 0.35
   leaner_query_weight_importance__user_breadth: 0.25
@@ -62,10 +55,11 @@ vars:
   leaner_query_stage_dataset_names: []
 
   leaner_query_custom_clients: []
-  
   # principal emails used for egress
-  leaner_query_custom_egress_emails: []  
+  leaner_query_custom_egress_emails: []
 
   leaner_query_bq_on_demand_pricing: 6.225
-  leaner_query_bq_slot_pricing: {'standard': 0.04, 'enterprise': 0.06, 'enterprise_plus' : 0.10}
+  leaner_query_bq_slot_pricing: {'standard': 0.04, 'enterprise': 0.06, 'enterprise_plus': 0.10}
   leaner_query_bq_pricing_schedule: on_demand
+flags:
+  require_generic_test_arguments_property: true

--- a/macros/test_unique_combination_of_columns.sql
+++ b/macros/test_unique_combination_of_columns.sql
@@ -9,7 +9,7 @@
 {% elif quote_columns %}
     {%- set column_list=[] %}
         {% for column in combination_of_columns -%}
-            {% set column_list = column_list.append( adapter.quote(column) ) %}
+            {% do column_list.append( adapter.quote(column) ) %}
         {%- endfor %}
 {% else %}
     {{ exceptions.raise_compiler_error(

--- a/models/marts/bigquery_audit_log.yml
+++ b/models/marts/bigquery_audit_log.yml
@@ -9,7 +9,7 @@ models:
         description: Foreign key for dim_job - surrogate of job_id
         tests:
           - not_null
-  
+
       - name: referenced_view_or_table
         description: The table or view being referenced
 
@@ -31,7 +31,7 @@ models:
         tests:
           - not_null
           - unique
-    
+
       - name: principal_email
         description: User email initiating bigquery job
 
@@ -40,7 +40,7 @@ models:
 
       - name: user_type
         description: Whether the user is a service account or a real user
-      
+
       - name: project_id
         description: BQ project associated with the user ID.
 
@@ -52,7 +52,7 @@ models:
         description: Surrogate key - built from caller_supplied_user_agent
         tests:
           - not_null
-    
+
       - name: caller_supplied_user_agent
         description: user agent supplied with the job
 
@@ -65,7 +65,7 @@ models:
     columns:
       - name: error_message_key
         description: Surrogate key - built from error_result_code and error_result_message
-      
+
       - name: error_result_code
         description: The Warehouse's code used to describe the error
 
@@ -76,9 +76,10 @@ models:
     description: Houses label keys, values, and job ids
     tests:
       - unique_combination_of_columns:
-          combination_of_columns:
-            - job_key
-            - label_key
+          arguments:
+            combination_of_columns:
+              - job_key
+              - label_key
 
     columns:
       - name: job_key

--- a/models/reports/rpt_bigquery_dbt_metrics_daily.sql
+++ b/models/reports/rpt_bigquery_dbt_metrics_daily.sql
@@ -7,7 +7,7 @@
 
 {{ 
     config(
-        enable = var("leaner_query_enable_reports"),
+        enabled = var("leaner_query_enable_reports"),
         require_partition_filter = var("leaner_query_require_partition_by_reports"),
         partition_by = {
         "field": "report_date",

--- a/models/reports/rpt_bigquery_query_alerting.sql
+++ b/models/reports/rpt_bigquery_query_alerting.sql
@@ -7,7 +7,7 @@
 
 {{
     config(
-        enable = var("leaner_query_enable_reports"),
+        enabled = var("leaner_query_enable_reports"),
         require_partition_filter = var("leaner_query_require_partition_by_reports"),
         materialized='incremental',
         cluster_by = ['username', 'user_type'],

--- a/models/reports/rpt_bigquery_table_usage_daily.sql
+++ b/models/reports/rpt_bigquery_table_usage_daily.sql
@@ -7,7 +7,7 @@
 
 {{ 
     config(
-        enable = var("leaner_query_enable_reports"),
+        enabled = var("leaner_query_enable_reports"),
         require_partition_filter = var("leaner_query_require_partition_by_reports"),
         materialized='incremental',
         cluster_by = ['layer', 'client_type'],

--- a/models/reports/rpt_bigquery_usage_cost_daily.sql
+++ b/models/reports/rpt_bigquery_usage_cost_daily.sql
@@ -7,7 +7,7 @@
 
 {{ 
     config(
-        enable = var("leaner_query_enable_reports"),
+        enabled = var("leaner_query_enable_reports"),
         require_partition_filter = var("leaner_query_require_partition_by_reports"),
         partition_by = {
         "field": "report_date",

--- a/models/reports/rpt_bigquery_user_metrics_daily.sql
+++ b/models/reports/rpt_bigquery_user_metrics_daily.sql
@@ -7,7 +7,7 @@
 
 {{ 
     config(
-        enable = var("leaner_query_enable_reports"),
+        enabled = var("leaner_query_enable_reports"),
         require_partition_filter = var("leaner_query_require_partition_by_reports"),
         cluster_by = ['username', 'user_type'],
         partition_by={


### PR DESCRIPTION
I wasn't able to test the package entirely but I did a `dbtf parse` and `dbtf compile` and fixed the errors I saw.

I think that the new version of the package is now compatible with Core >=1.10.5 (the first Core version supporting the `arguments:` key for tests) and Fusion as expected.

Would you be able to have a look at the PR and do a new release?
Please, let me know if you have any question.