### PR TITLE
Dbt 111 and microbatch strategy

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'leaner_query'
-version: '1.0.0'
+version: '0.2.3'
 config-version: 2
 
 profile: 'leaner_query'

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -4,7 +4,7 @@ config-version: 2
 
 profile: 'leaner_query'
 
-require-dbt-version: [">=1.3.0", "<2.0.0"]
+require-dbt-version: [">=1.11.0", "<2.0.0"]
 
 target-path: "target"
 clean-targets:
@@ -51,6 +51,11 @@ vars:
 
   leaner_query_dev_limit_days: 30
   leaner_query_dev_target_name: ['dev']
+
+  # Microbatch controls for audit-log/query-history derived models
+  # - Example: set to 30 to (re)build last 30 days each run
+  leaner_query_microbatch_days: 3
+  leaner_query_microbatch_include_today: true
 
   #Client types
   leaner_query_importance_query_score_1: ['Web console']

--- a/macros/leaner_query_microbatch_where.sql
+++ b/macros/leaner_query_microbatch_where.sql
@@ -1,0 +1,39 @@
+{% macro leaner_query_microbatch_where(column_name, data_type) %}
+  {#-
+    Returns a SQL predicate limiting rows to the current microbatch window.
+
+    Vars:
+      - leaner_query_microbatch_days (int)
+      - leaner_query_microbatch_include_today (bool)
+
+    `data_type`:
+      - 'date': compares DATE(<column_name>)
+      - 'timestamp': compares TIMESTAMP(<column_name>) truncated to day
+  -#}
+
+  {% set days = var('leaner_query_microbatch_days', 3) | int %}
+  {% set include_today = var('leaner_query_microbatch_include_today', true) %}
+
+  {% if days < 0 %}
+    {% set days = 0 %}
+  {% endif %}
+
+  {% if data_type == 'date' %}
+    {% if include_today %}
+      date({{ column_name }}) >= date_sub(current_date, interval {{ days }} day)
+    {% else %}
+      date({{ column_name }}) >= date_sub(current_date, interval {{ days }} day)
+      and date({{ column_name }}) < current_date
+    {% endif %}
+  {% elif data_type == 'timestamp' %}
+    {% if include_today %}
+      timestamp_trunc(cast({{ column_name }} as timestamp), day) >= timestamp_trunc(timestamp_sub(current_timestamp, interval {{ days }} day), day)
+    {% else %}
+      timestamp_trunc(cast({{ column_name }} as timestamp), day) >= timestamp_trunc(timestamp_sub(current_timestamp, interval {{ days }} day), day)
+      and timestamp_trunc(cast({{ column_name }} as timestamp), day) < timestamp_trunc(current_timestamp, day)
+    {% endif %}
+  {% else %}
+    {{ exceptions.raise_compiler_error("leaner_query_microbatch_where: data_type must be 'date' or 'timestamp'") }}
+  {% endif %}
+{% endmacro %}
+

--- a/macros/leaner_query_partitions_to_replace.sql
+++ b/macros/leaner_query_partitions_to_replace.sql
@@ -1,0 +1,41 @@
+{% macro leaner_query_partitions_to_replace(data_type) %}
+  {#-
+    Returns a list of partition expressions suitable for BigQuery's insert_overwrite `partitions` config.
+
+    Controlled via vars:
+      - leaner_query_microbatch_days (int): number of prior days to include
+      - leaner_query_microbatch_include_today (bool): include current day partition
+
+    `data_type` must be 'date' or 'timestamp'.
+  -#}
+
+  {% set days = var('leaner_query_microbatch_days', 3) | int %}
+  {% set include_today = var('leaner_query_microbatch_include_today', true) %}
+
+  {% if days < 0 %}
+    {% set days = 0 %}
+  {% endif %}
+
+  {% set parts = [] %}
+
+  {% if data_type == 'date' %}
+    {% for i in range(days, 0, -1) %}
+      {% do parts.append("date(date_add(current_date, interval -" ~ i ~ " day))") %}
+    {% endfor %}
+    {% if include_today %}
+      {% do parts.append("date(current_date)") %}
+    {% endif %}
+  {% elif data_type == 'timestamp' %}
+    {% for i in range(days, 0, -1) %}
+      {% do parts.append("timestamp(timestamp_add(current_timestamp, interval -" ~ i ~ " day))") %}
+    {% endfor %}
+    {% if include_today %}
+      {% do parts.append("timestamp(current_timestamp)") %}
+    {% endif %}
+  {% else %}
+    {{ exceptions.raise_compiler_error("leaner_query_partitions_to_replace: data_type must be 'date' or 'timestamp'") }}
+  {% endif %}
+
+  {{ return(parts) }}
+{% endmacro %}
+

--- a/models/intermediate/int_importance_calculations.sql
+++ b/models/intermediate/int_importance_calculations.sql
@@ -1,9 +1,4 @@
-{% set partitions_to_replace = [
-    'date(date_add(current_date, interval -3 day))',
-    'date(date_add(current_date, interval -2 day))',
-    'date(date_add(current_date, interval -1 day))',
-    'date(current_date)'
-] %}
+{% set partitions_to_replace = leaner_query_partitions_to_replace('date') %}
 
 {{ 
     config(
@@ -23,7 +18,7 @@ with fct_executed_statements as (
     from {{ ref('fct_executed_statements') }}
     where 1=1
     {% if is_incremental() %}
-        and date(statement_date) >= current_date - 3
+        and statement_date in ({{ partitions_to_replace | join(',') }})
     {% endif %}
     {% if target.name in var('leaner_query_dev_target_name') and var('leaner_query_enable_dev_limits') %}
         and date(statement_date) >= current_date - {{ var('leaner_query_dev_limit_days') }}

--- a/models/intermediate/int_table_active_users.sql
+++ b/models/intermediate/int_table_active_users.sql
@@ -1,9 +1,4 @@
-{% set partitions_to_replace = [
-    'date(date_add(current_date, interval -3 day))',
-    'date(date_add(current_date, interval -2 day))',
-    'date(date_add(current_date, interval -1 day))',
-    'date(current_date)'
-] %}
+{% set partitions_to_replace = leaner_query_partitions_to_replace('date') %}
 
 {{ 
     config(
@@ -23,7 +18,7 @@ with source as(
     from {{ ref('stg_bigquery_audit_log__data_access') }}
     where principal_email not like '%.iam.gserviceaccount.com'
     {% if is_incremental() %}
-        and date(event_timestamp) >= current_date - 3
+        and date(event_timestamp) in ({{ partitions_to_replace | join(',') }})
     {% endif %}
     {% if target.name in var('leaner_query_dev_target_name') and var('leaner_query_enable_dev_limits') %}
         and date(event_timestamp) >= current_date - {{ var('leaner_query_dev_limit_days') }}

--- a/models/intermediate/int_threat_calculation.sql
+++ b/models/intermediate/int_threat_calculation.sql
@@ -1,9 +1,4 @@
-{% set partitions_to_replace = [
-    'date(date_add(current_date, interval -3 day))',
-    'date(date_add(current_date, interval -2 day))',
-    'date(date_add(current_date, interval -1 day))',
-    'date(current_date)'
-] %}
+{% set partitions_to_replace = leaner_query_partitions_to_replace('date') %}
 
 {{ 
     config(
@@ -24,7 +19,7 @@ with statements as (
     from {{ ref('fct_executed_statements') }}   
     where 1=1
     {% if is_incremental() %}
-        and date(statement_date) >= current_date - 3
+        and statement_date in ({{ partitions_to_replace | join(',') }})
     {% endif %}
     {% if target.name in var('leaner_query_dev_target_name') and var('leaner_query_enable_dev_limits') %}
         and date(statement_date) >= current_date - {{ var('leaner_query_dev_limit_days') }}

--- a/models/marts/dim_bigquery_users.sql
+++ b/models/marts/dim_bigquery_users.sql
@@ -12,7 +12,7 @@ with source as (
     from {{ ref('stg_bigquery_audit_log__data_access') }}
     where 1=1
     {% if is_incremental() %}
-        and date(event_timestamp) >= current_date - 3
+        and {{ leaner_query_microbatch_where('event_timestamp', 'date') }}
     {% endif %}
     {% if target.name in var('leaner_query_dev_target_name') and var('leaner_query_enable_dev_limits') %}
         and date(event_timestamp) >= current_date - {{ var('leaner_query_dev_limit_days') }}

--- a/models/marts/dim_error_messages.sql
+++ b/models/marts/dim_error_messages.sql
@@ -14,7 +14,7 @@ with data_access as (
     from {{ ref('stg_bigquery_audit_log__data_access') }}
     where 1=1
     {% if is_incremental() %}
-        and date(event_timestamp) >= current_date - 3
+        and {{ leaner_query_microbatch_where('event_timestamp', 'date') }}
     {% endif %}
     {% if target.name in var('leaner_query_dev_target_name') and var('leaner_query_enable_dev_limits') %}
         and date(event_timestamp) >= current_date - {{ var('leaner_query_dev_limit_days') }}

--- a/models/marts/dim_job.sql
+++ b/models/marts/dim_job.sql
@@ -11,7 +11,7 @@ with data_access as (
     from {{ ref('stg_bigquery_audit_log__data_access') }}
     where 1=1
     {% if is_incremental() %}
-        and date(event_timestamp) >= current_date - 3
+        and {{ leaner_query_microbatch_where('event_timestamp', 'date') }}
     {% endif %}
     {% if target.name in var('leaner_query_dev_target_name') and var('leaner_query_enable_dev_limits') %}
         and date(event_timestamp) >= current_date - {{ var('leaner_query_dev_limit_days') }}

--- a/models/marts/dim_job_labels.sql
+++ b/models/marts/dim_job_labels.sql
@@ -12,7 +12,7 @@ with source as (
     from {{ ref('stg_bigquery_audit_log__data_access') }}
     where 1=1
     {% if is_incremental() %}
-        and date(event_timestamp) >= current_date - 3
+        and {{ leaner_query_microbatch_where('event_timestamp', 'date') }}
     {% endif %}
     {% if target.name in var('leaner_query_dev_target_name') and var('leaner_query_enable_dev_limits') %}
         and date(event_timestamp) >= current_date - {{ var('leaner_query_dev_limit_days') }}

--- a/models/marts/dim_job_table_view_references.sql
+++ b/models/marts/dim_job_table_view_references.sql
@@ -11,7 +11,7 @@ with source as (
     from {{ ref('stg_bigquery_audit_log__data_access') }}
     where 1=1
     {% if is_incremental() %}
-        and date(event_timestamp) >= current_date - 3
+        and {{ leaner_query_microbatch_where('event_timestamp', 'date') }}
     {% endif %}
     {% if target.name in var('leaner_query_dev_target_name') and var('leaner_query_enable_dev_limits') %}
         and date(event_timestamp) >= current_date - {{ var('leaner_query_dev_limit_days') }}

--- a/models/marts/dim_query_statements.sql
+++ b/models/marts/dim_query_statements.sql
@@ -11,7 +11,7 @@ with data_access as (
     from {{ ref('stg_bigquery_audit_log__data_access') }}
     where 1=1
     {% if is_incremental() %}
-        and date(event_timestamp) >= current_date - 3
+        and {{ leaner_query_microbatch_where('event_timestamp', 'date') }}
     {% endif %}
     {% if target.name in var('leaner_query_dev_target_name') and var('leaner_query_enable_dev_limits') %}
         and date(event_timestamp) >= current_date - {{ var('leaner_query_dev_limit_days') }}

--- a/models/marts/dim_user_agents.sql
+++ b/models/marts/dim_user_agents.sql
@@ -11,7 +11,7 @@ with source as(
     from {{ ref('stg_bigquery_audit_log__data_access') }}
     where 1=1
     {% if is_incremental() %}
-        and date(event_timestamp) >= current_date - 3
+        and {{ leaner_query_microbatch_where('event_timestamp', 'date') }}
     {% endif %}
     {% if target.name in var('leaner_query_dev_target_name') and var('leaner_query_enable_dev_limits') %}
         and date(event_timestamp) >= current_date - {{ var('leaner_query_dev_limit_days') }}

--- a/models/marts/fct_executed_statements.sql
+++ b/models/marts/fct_executed_statements.sql
@@ -1,9 +1,4 @@
-{% set partitions_to_replace = [
-    'date(date_add(current_date, interval -3 day))',
-    'date(date_add(current_date, interval -2 day))',
-    'date(date_add(current_date, interval -1 day))',
-    'date(current_date)'
-] %}
+{% set partitions_to_replace = leaner_query_partitions_to_replace('date') %}
 
 {{ 
     config(
@@ -24,7 +19,7 @@ with source as (
     from {{ ref('stg_bigquery_audit_log__data_access') }}
     where 1=1
     {% if is_incremental() %}
-        and date(event_timestamp) >= current_date - 3
+        and date(event_timestamp) in ({{ partitions_to_replace | join(',') }})
     {% endif %}
     {% if target.name in var('leaner_query_dev_target_name') and var('leaner_query_enable_dev_limits') %}
         and date(event_timestamp) >= current_date - {{ var('leaner_query_dev_limit_days') }}

--- a/models/reports/rpt_bigquery_dbt_metrics_daily.sql
+++ b/models/reports/rpt_bigquery_dbt_metrics_daily.sql
@@ -1,9 +1,4 @@
-{% set partitions_to_replace = [
-    'date(date_add(current_date, interval -3 day))',
-    'date(date_add(current_date, interval -2 day))',
-    'date(date_add(current_date, interval -1 day))',
-    'date(current_date)'
-] %}
+{% set partitions_to_replace = leaner_query_partitions_to_replace('date') %}
 
 {{ 
     config(

--- a/models/reports/rpt_bigquery_query_alerting.sql
+++ b/models/reports/rpt_bigquery_query_alerting.sql
@@ -1,9 +1,4 @@
-{% set partitions_to_replace = [
-    'timestamp(timestamp_add(current_timestamp, interval -3 day))',
-    'timestamp(timestamp_add(current_timestamp, interval -2 day))',
-    'timestamp(timestamp_add(current_timestamp, interval -1 day))',
-    'timestamp(current_timestamp)'
-] %}
+{% set partitions_to_replace = leaner_query_partitions_to_replace('timestamp') %}
 
 {{
     config(
@@ -55,7 +50,7 @@ final as (
         on users.user_key = statements.user_key
     inner join query_statements
         on query_statements.job_key = statements.job_key
-    where date(statements.start_time) >= current_date -2
+    where {{ leaner_query_microbatch_where('statements.start_time', 'date') }}
 )
 
 select *

--- a/models/reports/rpt_bigquery_table_usage_daily.sql
+++ b/models/reports/rpt_bigquery_table_usage_daily.sql
@@ -1,9 +1,4 @@
-{% set partitions_to_replace = [
-    'date(date_add(current_date, interval -3 day))',
-    'date(date_add(current_date, interval -2 day))',
-    'date(date_add(current_date, interval -1 day))',
-    'date(current_date)'
-] %}
+{% set partitions_to_replace = leaner_query_partitions_to_replace('date') %}
 
 {{ 
     config(

--- a/models/reports/rpt_bigquery_usage_cost_daily.sql
+++ b/models/reports/rpt_bigquery_usage_cost_daily.sql
@@ -1,9 +1,4 @@
-{% set partitions_to_replace = [
-    'date(date_add(current_date, interval -3 day))',
-    'date(date_add(current_date, interval -2 day))',
-    'date(date_add(current_date, interval -1 day))',
-    'date(current_date)'
-] %}
+{% set partitions_to_replace = leaner_query_partitions_to_replace('date') %}
 
 {{ 
     config(

--- a/models/reports/rpt_bigquery_user_metrics_daily.sql
+++ b/models/reports/rpt_bigquery_user_metrics_daily.sql
@@ -1,9 +1,4 @@
-{% set partitions_to_replace = [
-    'date(date_add(current_date, interval -3 day))',
-    'date(date_add(current_date, interval -2 day))',
-    'date(date_add(current_date, interval -1 day))',
-    'date(current_date)'
-] %}
+{% set partitions_to_replace = leaner_query_partitions_to_replace('date') %}
 
 {{ 
     config(

--- a/profiles.example.yml
+++ b/profiles.example.yml
@@ -1,0 +1,12 @@
+leaner_query:
+  target: dev
+  outputs:
+    dev:
+      type: bigquery
+      method: oauth
+      project: YOUR_GCP_PROJECT_ID
+      dataset: leaner_query
+      location: US
+      threads: 4
+      priority: interactive
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Eventually it would be preferrable to have a specific version to ensure
 # that we're all in sync and are preventing dependency pain
 
-dbt-bigquery==1.3.0
-sqlfluff==1.4.2
-sqlfluff-templater-dbt==1.4.2
+dbt-bigquery==1.11.0
+sqlfluff==3.0.7
+sqlfluff-templater-dbt==3.0.7
 diff-cover==7.2.0


### PR DESCRIPTION
# Microbatch window for audit-log and incremental models

## Problem

Models that read BigQuery audit logs or large query-history sources, and incremental models keyed by day, previously implied scanning or reconciling **much wider** time ranges than needed for routine runs. That increases cost, runtime, and lock contention without improving day-to-day freshness.

## Approach

Introduce a **single, configurable rolling window** (in days) shared across the package via two macros:

1. **`leaner_query_microbatch_where(column_name, data_type)`**  
   Emits a SQL predicate that limits rows to the current microbatch window.  
   - `data_type`: `'date'` (compares `DATE(column)`) or `'timestamp'` (day-truncated timestamp comparison).  
   - Used to **cap upstream reads** on audit-log–backed dimensions and on alerting logic that filters by statement time.

2. **`leaner_query_partitions_to_replace(data_type)`**  
   Returns a list of partition expressions for BigQuery **`insert_overwrite`** `partitions` config, aligned to the **same** window as the WHERE macro.  
   - Keeps incremental **partition replacement** scoped to the microbatch instead of replacing an unbounded set of partitions.

Negative `leaner_query_microbatch_days` is clamped to `0` in both macros.

## Configuration

Set in the parent project (or CLI) as needed. Defaults live in `dbt_project.yml`:

| Var | Role |
|-----|------|
| `leaner_query_microbatch_days` | Length of the rolling window in days (default `3`). Increase for backfills or slower-changing environments. |
| `leaner_query_microbatch_include_today` | If `true`, the window includes “today”; if `false`, the upper bound is yesterday so today’s partition is excluded from the window where applicable. |

## Where it is applied

**`partitions_to_replace` (incremental insert_overwrite, date unless noted)**

- `models/intermediate/int_importance_calculations.sql`
- `models/intermediate/int_table_active_users.sql`
- `models/intermediate/int_threat_calculation.sql`
- `models/marts/fct_executed_statements.sql`
- `models/reports/rpt_bigquery_dbt_metrics_daily.sql`
- `models/reports/rpt_bigquery_query_alerting.sql` — **`timestamp`** partitions
- `models/reports/rpt_bigquery_table_usage_daily.sql`
- `models/reports/rpt_bigquery_usage_cost_daily.sql`
- `models/reports/rpt_bigquery_user_metrics_daily.sql`

**`leaner_query_microbatch_where` on `event_timestamp` (date)**

- `dim_bigquery_users`, `dim_error_messages`, `dim_job`, `dim_job_labels`, `dim_job_table_view_references`, `dim_query_statements`, `dim_user_agents`

**`leaner_query_microbatch_where` on statement time**

- `rpt_bigquery_query_alerting.sql` — `statements.start_time` as **`date`**
